### PR TITLE
feat: bump the facebook app events sdk to v17.0.1

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -74,4 +74,4 @@ jobs:
           github_token: ${{ secrets.PAT }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body:  ":crown: *An automated PR*"
-          pr_reviewer: 'itsdebs'
+          pr_reviewer: '@rudderlabs/sdk-android'

--- a/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
+++ b/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
@@ -19,7 +19,7 @@ jobs:
           outdated-dependency-names: "com.facebook.android:facebook-android-sdk"
           directory: "facebook/build.gradle"
           title: "fix: update Facebook SDK to the latest version"
-          assignee: "desusai7"
+          assignee: "@rudderlabs/sdk-android"
           labels: "outdatedDependency"
           color: "FBCA04"
         env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @rudderlabs/sdk-android

--- a/README.md
+++ b/README.md
@@ -13,23 +13,11 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
   - Turning on the switch beside `Initialize Native SDK to send automated events` in the dashboard will initialize the Facebook native SDK in the application.
   - Turning on the switch beside `Use native SDK to send user generated events` in the dashboard will instruct your `data-plane` to skip the events for Facebook and the events will be sent from the Facebook SDK.
 
-3. Add these lines to your ```app/build.gradle```
-```
-repositories {
-    maven { url "https://dl.bintray.com/rudderstack/rudderstack" }
-}
-```
-4. Add the dependency under ```dependencies```
+3. Add the dependency under ```dependencies``` section of your `app/build.gradle` file:
 ```
 // Rudder core sdk and facebook extension
-implementation 'com.rudderstack.android.sdk:core:1.0.2'
-implementation 'com.rudderstack.android.integration:facebook:1.0.0'
-
-// facebook core sdk
-implementation 'com.facebook.android:facebook-android-sdk:5.9.0'
-
-// gson
-implementation 'com.google.code.gson:gson:2.8.6'
+implementation 'com.rudderstack.android.sdk:core:x.y.z'
+implementation 'com.rudderstack.android.integration:facebook:x.y.z'
 ```
 
 ## Initialize ```RudderClient```

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -29,8 +29,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
 
-    compileOnly 'com.rudderstack.android.sdk:core:[1.12.0, 2.0.0)'
-    implementation 'com.facebook.android:facebook-android-sdk:16.0.1'
+    compileOnly 'com.rudderstack.android.sdk:core:[1.25.0, 2.0.0)'
+    implementation 'com.facebook.android:facebook-android-sdk:17.0.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
 

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
-    implementation 'com.rudderstack.android.sdk:core:[1.0,2.0)'
+    implementation 'com.rudderstack.android.sdk:core:[1.25.0,2.0)'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation project(':facebook')
 

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -14,6 +14,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+Properties properties = new Properties()
+if (project.rootProject.file('sample-kotlin/local.properties').canRead()) {
+    properties.load(project.rootProject.file("sample-kotlin/local.properties").newDataInputStream())
+}
+
 android {
     compileSdkVersion 32
     defaultConfig {
@@ -23,6 +28,10 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "DATA_PLANE_URL", properties.getProperty('dataplaneUrl', "\"https://hosted.rudderlabs.com\""))
+        buildConfigField("String", "CONTROL_PLANE_URL", properties.getProperty('controlplaneUrl', "\"https://api.rudderstack.com\""))
+        buildConfigField("String", "WRITE_KEY", properties.getProperty('writeKey', "\"\""))
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/sample-kotlin/local.properties.sample
+++ b/sample-kotlin/local.properties.sample
@@ -1,0 +1,3 @@
+dataplaneUrl="your_dp_url"
+controlplaneUrl="control_plane_url"
+writeKey="your_write_key"

--- a/sample-kotlin/src/main/AndroidManifest.xml
+++ b/sample-kotlin/src/main/AndroidManifest.xml
@@ -21,9 +21,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
-
-        <!-- Refer to the Facebook docL https://developers.facebook.com/docs/app-events/getting-started-app-events-android-->
+        <!-- Refer to the Facebook doc: https://developers.facebook.com/docs/android/getting-started-->
         <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
         <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>
     </application>

--- a/sample-kotlin/src/main/java/com/rudderlabs/android/sample/kotlin/MainApplication.kt
+++ b/sample-kotlin/src/main/java/com/rudderlabs/android/sample/kotlin/MainApplication.kt
@@ -9,9 +9,6 @@ import com.rudderstack.android.sdk.core.RudderLogger
 
 class MainApplication : Application() {
     companion object {
-        private const val WRITE_KEY = "1wD4YINtPQW9lwdAXsc38ZlRW0k"
-        private const val DATA_PLANE_URL = "https://285b83208a68.ngrok.io"
-        private const val CONTROL_PLANE_URL = "https://sour-pig-84.loca.lt"
         lateinit var rudderClient: RudderClient
     }
 
@@ -19,10 +16,10 @@ class MainApplication : Application() {
         super.onCreate()
         rudderClient = RudderClient.getInstance(
             this,
-            WRITE_KEY,
+            BuildConfig.WRITE_KEY,
             RudderConfig.Builder()
-                .withDataPlaneUrl(DATA_PLANE_URL)
-                .withControlPlaneUrl(CONTROL_PLANE_URL)
+                .withDataPlaneUrl(BuildConfig.DATA_PLANE_URL)
+                .withControlPlaneUrl(BuildConfig.CONTROL_PLANE_URL)
                 .withLogLevel(RudderLogger.RudderLogLevel.VERBOSE)
                 .withFactory(FacebookIntegrationFactory.FACTORY)
                 .withTrackLifecycleEvents(false)

--- a/sample-kotlin/src/main/res/values/strings.xml
+++ b/sample-kotlin/src/main/res/values/strings.xml
@@ -1,8 +1,7 @@
 <resources>
     <string name="app_name">RudderAndroidClient</string>
-    <!-- Refer to the Facebook docL https://developers.facebook.com/docs/app-events/getting-started-app-events-android-->
+    <!-- Refer to the Facebook doc: https://developers.facebook.com/docs/android/getting-started-->
     <string name="facebook_app_id">APPID</string>
-    <string name="fb_login_protocol_scheme">fbAPPID</string>
     <string name="facebook_client_token">CLIENTOKEN</string>
 
 </resources>


### PR DESCRIPTION
## Description

- In this PR, we have updated the Facebook App Events to the latest version `17.0.1`.
- Added the setup to provide Android configuration values in local.properties.
- Update codeowners and PR reviewers.
- Updated the minimum Android SDK version to the latest.
- Updated Readme.md

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
