### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read  # GITHUB_TOKEN only needs read for checkout
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,10 +19,20 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write  # to create commits, tags, and push changes
+          permission-pull-requests: write  # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -81,7 +91,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body:  ":crown: *An automated PR*"
           pr_reviewer: '@rudderlabs/sdk-android'

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write  # to create commits, tags, and push changes
           permission-pull-requests: write  # to create and update PRs
+          permission-members: read # to resolve team reviewers
 
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -39,13 +39,6 @@ jobs:
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
         id: create-release
@@ -56,7 +49,7 @@ jobs:
           git fetch origin master --depth=1
           git merge origin/master
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
-          
+
           npm ci
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
@@ -69,22 +62,39 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
-          
+
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Create release branch via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse origin/master)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release
         run: |
           npm ci
-          npx standard-version -a --skip.tag
+          npx standard-version -a --skip.commit --skip.tag
 
-      - name: Push new version in release branch
-        run: |
-          git push
+      - name: Create verified commit and tag via GitHub API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            gradle.properties
+            package.json
+            package-lock.json
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -15,12 +15,23 @@ jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # GITHUB_TOKEN only needs read for checkout
     if:  ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write  # to create tags and releases
+          permission-pull-requests: write  # to update PR metadata
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -37,6 +48,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -53,8 +65,7 @@ jobs:
       - name: Create Github Release & Tag
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
           git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
@@ -66,4 +77,4 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token
- Adds explicit permissions at job level with comments explaining why
- Follows January 2026 security best practices for GitHub Actions
- **Simplifies draft_new_release.yml using ryancyq/github-signed-commit pattern**

### Files Changed
- `.github/workflows/notion_pr_sync.yml` - Migrated to GITHUB_TOKEN
- `.github/workflows/draft_new_release.yml` - Migrated to GitHub App Token + simplified with signed-commit pattern
- `.github/workflows/publish-new-github-release.yml` - Migrated to GitHub App Token

### Migration Details
| File | Token Type | Permissions | Rationale |
|------|------------|-------------|-----------|
| `notion_pr_sync.yml` | GITHUB_TOKEN | `pull-requests: read` | Only reads PR metadata for Notion sync - no App Token needed |
| `draft_new_release.yml` | GitHub App Token | `contents: write, pull-requests: write` | Creates release PRs that must trigger CI checks + verified commits |
| `publish-new-github-release.yml` | GitHub App Token | `contents: write, pull-requests: write` | Creates tags and releases that must trigger CI checks |

### Changes Made

#### 1. notion_pr_sync.yml
- Added job-level `permissions: pull-requests: read`
- Replaced `secrets.PAT` with `secrets.GITHUB_TOKEN`

#### 2. draft_new_release.yml (UPDATED with Simplified Pattern)
- Updated job-level permissions from `contents: write` to `contents: read`
- Added GitHub App Token generation step (early in workflow)
- Passed App Token to `actions/checkout` via `token:` input
- **REMOVED**: `git config user.name/email` steps (no longer needed)
- **REMOVED**: `git checkout -b` + `git push --set-upstream` (replaced with API)
- **REPLACED**: Manual git push with `ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f` for verified commits
- **REPLACED**: Branch creation using GitHub API (`gh api repos/.../git/refs`)
- **ADDED**: `--skip.commit --skip.tag` flags to standard-version
- Replaced `secrets.PAT` with `steps.generate-token.outputs.token` in PR creation

#### 3. publish-new-github-release.yml
- Added job-level `permissions: contents: read`
- Added GitHub App Token generation step (early in workflow)
- Passed App Token to `actions/checkout` via `token:` input
- Replaced `secrets.PAT` with `steps.generate-token.outputs.token` in release creation and branch deletion
- Removed unused `GITHUB_TOKEN` env var

### Key Simplifications (draft_new_release.yml)

The new pattern eliminates several steps by using GitHub API for commits:

| Removed | Why No Longer Needed |
|---------|---------------------|
| `git config user.name/email` | Signed commit uses App identity |
| `git checkout -b` + `git push --set-upstream` | Branch created via GitHub API |
| `git push` | Commit created via GitHub API |
| Token-in-URL patterns | API handles authentication |

**Benefits:**
- Cleaner, more secure code
- Verified commits by default (GitHub API creates verified commits)
- No credential embedding in git URLs
- Follows best practices from rudder-consent-filters-android #21

### Security Improvements
- Follows principle of least privilege (minimal GITHUB_TOKEN permissions)
- App Token generated early and used for all write operations
- Clear permission comments explain why each permission is needed
- Verified commits via GitHub API (more secure than git push)
- No new linter errors introduced (all pre-existing issues remain unchanged)

## Test plan
- [ ] Verify all workflows pass after merge
- [ ] Test draft release workflow creates PRs that trigger CI
- [ ] Test publish release workflow creates releases successfully
- [ ] Verify Notion PR sync continues to work
- [ ] Verify release commits are marked as "Verified" on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)